### PR TITLE
feat(ghes): fetch tool from configurable server

### DIFF
--- a/.github/linters/.cspell.yml
+++ b/.github/linters/.cspell.yml
@@ -15,3 +15,5 @@ words:
   - codespell
   - MYENVPREFIX
   - stefanzweifel
+  - GHES
+  - rhysd

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Action returns some basic information. For more details, follow [📤 Outputs](#
 |    `pyflakes`    |  false   |  `bool`  |      `true`      | Use `pyflakes` with `actionlint` (and install if it does not exist)                                                                                         |
 |     `cache`      |  false   |  `bool`  |      `true`      | Use GitHub cache for caching binaries for the next runs.                                                                                                    |
 |  `github-token`  |  false   | `string` |  `github.token`  | GitHub Token for API authentication.                                                                                                                        |
+| `github-server-url` | false | `string` | `https://github.com` | GitHub server to download the actionlint tool from. Defaults to public github.com; override only if you mirror `rhysd/actionlint` on your GHES. |
 
 ## 📤 Outputs
 

--- a/README.md
+++ b/README.md
@@ -68,24 +68,24 @@ Action returns some basic information. For more details, follow [📤 Outputs](#
 
 ## 📥 Inputs
 
-|       Name       | Required |   Type   |  Default value   | Description                                                                                                                                                 |
-| :--------------: | :------: | :------: | :--------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|    `version`     |  false   | `string` |     `latest`     | SemVer version of `actionlint`, recommended to keep default: `latest`                                                                                       |
-|    `matcher`     |  false   |  `bool`  |      `true`      | Use matcher for GitHub annotations.                                                                                                                         |
-|     `files`      |  false   | `string` |    _not set_     | To lint different workflow files (default searching directory is `.github/workflows`), use comma-separated glob patterns, e.g., `tests/*.yml, tests/*.yaml` |
-|     `flags`      |  false   | `string` |    _not set_     | Extra flags to use with `actionlint`                                                                                                                        |
-|  `group-result`  |  false   |  `bool`  |      `true`      | Use the GitHub log grouping feature for failure actionlint results.                                                                                         |
-| `fail-on-error`  |  false   |  `bool`  |      `true`      | Fail action on `actionlint` errors.                                                                                                                         |
-|   `shellcheck`   |  false   |  `bool`  |      `true`      | Use `shellcheck` with `actionlint` (and install if it does not exist)                                                                                       |
-|    `pyflakes`    |  false   |  `bool`  |      `true`      | Use `pyflakes` with `actionlint` (and install if it does not exist)                                                                                         |
-|     `cache`      |  false   |  `bool`  |      `true`      | Use GitHub cache for caching binaries for the next runs.                                                                                                    |
-|  `github-token`  |  false   | `string` |  `github.token`  | GitHub Token for API authentication.                                                                                                                        |
-| `github-server-url` | false | `string` | `https://github.com` | GitHub server to download the actionlint tool from. Defaults to public github.com; override only if you mirror `rhysd/actionlint` on your GHES. |
+|        Name         | Required |   Type   |    Default value     | Description                                                                                                                                                 |
+|:-------------------:|:--------:|:--------:|:--------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|      `version`      |  false   | `string` |       `latest`       | SemVer version of `actionlint`, recommended to keep default: `latest`                                                                                       |
+|      `matcher`      |  false   |  `bool`  |        `true`        | Use matcher for GitHub annotations.                                                                                                                         |
+|       `files`       |  false   | `string` |      _not set_       | To lint different workflow files (default searching directory is `.github/workflows`), use comma-separated glob patterns, e.g., `tests/*.yml, tests/*.yaml` |
+|       `flags`       |  false   | `string` |      _not set_       | Extra flags to use with `actionlint`                                                                                                                        |
+|   `group-result`    |  false   |  `bool`  |        `true`        | Use the GitHub log grouping feature for failure actionlint results.                                                                                         |
+|   `fail-on-error`   |  false   |  `bool`  |        `true`        | Fail action on `actionlint` errors.                                                                                                                         |
+|    `shellcheck`     |  false   |  `bool`  |        `true`        | Use `shellcheck` with `actionlint` (and install if it does not exist)                                                                                       |
+|     `pyflakes`      |  false   |  `bool`  |        `true`        | Use `pyflakes` with `actionlint` (and install if it does not exist)                                                                                         |
+|       `cache`       |  false   |  `bool`  |        `true`        | Use GitHub cache for caching binaries for the next runs.                                                                                                    |
+|   `github-token`    |  false   | `string` |    `github.token`    | GitHub Token for API authentication.                                                                                                                        |
+| `github-server-url` |  false   | `string` | `https://github.com` | GitHub server to download the actionlint tool from. Defaults to public github.com; override only if you mirror `rhysd/actionlint` on your GHES.             |
 
 ## 📤 Outputs
 
 |       Name       |   Type   | Description                                                                                                                    |
-| :--------------: | :------: | :----------------------------------------------------------------------------------------------------------------------------- |
+|:----------------:|:--------:|:-------------------------------------------------------------------------------------------------------------------------------|
 | `version-semver` | `string` | SemVer version of `actionlint`, recommended to keep default: latest                                                            |
 |  `version-tag`   | `string` | Use matcher for GitHub annotations                                                                                             |
 |   `exit-code`    |  `int`   | Exit status code based on [actionlint exit status](https://github.com/rhysd/actionlint/blob/main/docs/usage.md#exit-status)    |

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: GitHub Token
     required: false
     default: ${{ github.token }}
+  github-server-url:
+    description: GitHub server to download the actionlint tool from. Defaults to public github.com so the external rhysd/actionlint tool is always found; override only if you mirror rhysd/actionlint on your GHES, e.g. https://ghes.example.com
+    required: false
+    default: https://github.com
 outputs:
   version-semver:
     description: SemVer version
@@ -95,7 +99,7 @@ runs:
         github-token: ${{ inputs.github-token || inputs.token || env.GITHUB_TOKEN }}
         script: |
           // input envs
-          const { INPUT_TOOL_NAME, INPUT_TOOL_SEMVER, INPUT_REPO_OWNER, INPUT_REPO_NAME, RUNNER_TEMP } = process.env
+          const { INPUT_TOOL_NAME, INPUT_TOOL_SEMVER, INPUT_REPO_OWNER, INPUT_REPO_NAME, INPUT_GITHUB_SERVER_URL, RUNNER_TEMP } = process.env
 
           // define tool platform and arch
           const processPlatform = process.platform // https://nodejs.org/api/process.html#processplatform
@@ -147,16 +151,22 @@ runs:
               process.exit(core.ExitCode.Failure)
           }
 
+          // GitHub server to fetch the tool from (defaults to public github.com so the external
+          // rhysd/actionlint tool is always found; override via github-server-url for a GHES mirror)
+          const serverUrl = (INPUT_GITHUB_SERVER_URL || 'https://github.com').replace(/\/+$/, '')
+          const apiBaseUrl = serverUrl === 'https://github.com' ? 'https://api.github.com' : `${serverUrl}/api/v3`
+          const rawBaseUrl = serverUrl === 'https://github.com' ? 'https://raw.githubusercontent.com' : `${serverUrl}/raw`
+
           // resolve the release tag while avoiding GitHub API calls where possible
           // (REST calls count against the GITHUB_TOKEN rate limit, which busy CI can exhaust)
           const isLatest = !INPUT_TOOL_SEMVER || INPUT_TOOL_SEMVER === 'latest'
 
-          // discover the latest tag by following the redirect on the public releases/latest page (no API call)
+          // discover the latest tag by following the redirect on the releases/latest page (no API call)
           async function getLatestTagFromRedirect() {
             const https = await import('node:https')
             return await new Promise((resolve, reject) => {
               const request = https.get(
-                `https://github.com/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/releases/latest`,
+                `${serverUrl}/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/releases/latest`,
                 { headers: { 'user-agent': INPUT_TOOL_NAME } },
                 (res) => {
                   res.resume() // drain the response so the socket can close
@@ -175,9 +185,10 @@ runs:
 
           // proxy-aware fallback via the authenticated client; only used if the redirect approach fails
           async function getLatestTagFromApi() {
-            const response = await github.rest.repos.getLatestRelease({
+            const response = await github.request('GET /repos/{owner}/{repo}/releases/latest', {
               owner: INPUT_REPO_OWNER,
-              repo: INPUT_REPO_NAME
+              repo: INPUT_REPO_NAME,
+              baseUrl: apiBaseUrl
             })
             return response.data.tag_name
           }
@@ -197,8 +208,8 @@ runs:
 
           const versionSemVer = versionTag.replace(/^v/, '')
           const toolDirPath = core.toPlatformPath(`${RUNNER_TEMP}/${INPUT_TOOL_NAME}-${versionSemVer}`)
-          const toolDownloadUrl = `https://github.com/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/releases/download/${versionTag}/${INPUT_TOOL_NAME}_${versionSemVer}_${toolOs}_${toolArch}.${toolExt}`
-          const matcherDownloadUrl = `https://raw.githubusercontent.com/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/${versionTag}/.github/actionlint-matcher.json`
+          const toolDownloadUrl = `${serverUrl}/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/releases/download/${versionTag}/${INPUT_TOOL_NAME}_${versionSemVer}_${toolOs}_${toolArch}.${toolExt}`
+          const matcherDownloadUrl = `${rawBaseUrl}/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/${versionTag}/.github/actionlint-matcher.json`
           const matcherPath = core.toPlatformPath(`${toolDirPath}/actionlint-matcher.json`)
 
           // set outputs
@@ -216,6 +227,7 @@ runs:
         INPUT_REPO_OWNER: "rhysd"
         INPUT_REPO_NAME: "actionlint"
         INPUT_TOOL_SEMVER: ${{ inputs.version }}
+        INPUT_GITHUB_SERVER_URL: ${{ inputs.github-server-url }}
 
     - name: Set cache
       if: ${{ inputs.cache == 'true' }}


### PR DESCRIPTION
## 💌 Description

- Add option to set own GitHub REST API, default to GITHUB_API_URL
- Enforce actionlint version / matcher check from public github
- Inputs naming adjustments
- Update docs

## 🔗 Related issue

<!-- If your PR refers to a related issue, link it here. -->
Fixes: #14

## 🏗️ Type of change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples/docs/tutorials
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🚨 Security fix
- [x] ⬆️ Dependencies update

## ✅ Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`Code of Conduct`](https://github.com/raven-actions/actionlint/blob/main/.github/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`Contributing`](https://github.com/raven-actions/actionlint/blob/main/.github/CONTRIBUTING.md) guide.