### PR TITLE
fix: don't interfere with repo package.json

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -204,7 +204,7 @@ runs:
 
     - name: Install dependencies
       if: ${{ steps.tool-cache.outputs.cache-hit != 'true' }}
-      run: npm install @actions/tool-cache
+      run: npm install --no-save --ignore-scripts @actions/tool-cache
       shell: ${{ (runner.os == 'Windows' && 'pwsh') || 'bash' }}
       working-directory: ${{ inputs.working-directory }}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 💌 Description

This action will do an `npm install @actions/tool-cache`, by default in the current working directory. There is a configurable `inputs.working-directory`, but I haven't tested to see if using that will change the behavior I'm seeing.

Regardless of the configurable working directory, running `npm install <package>` in a JavaScript repository will modify `package.json`, its lockfile, and run lifecycle scripts. This can cause side effects because a GitHub action is unintentionally modifying the cloned code.

## 🔗 Related issue

<!-- If your PR refers to a related issue, link it here. -->
Fixes: N/A

## 📚 Type of change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📝 Examples / docs / tutorials
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🚨 Security fix
- [ ] ⬆️ Dependencies update

## ✔️ Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`Code of Conduct`](https://github.com/raven-actions/.workflows/blob/main/.github/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`Contributing`](https://github.com/raven-actions/.workflows/blob/main/.github/CONTRIBUTING.md) guide.
