### PR TITLE
fix: pin installed version of @actions/tool-cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -204,7 +204,7 @@ runs:
 
     - name: Install dependencies
       if: ${{ steps.tool-cache.outputs.cache-hit != 'true' }}
-      run: npm install --no-save --ignore-scripts @actions/tool-cache@3
+      run: npm install --no-save --ignore-scripts @actions/tool-cache@3.0.1
       shell: ${{ (runner.os == 'Windows' && 'pwsh') || 'bash' }}
       working-directory: ${{ inputs.working-directory }}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 💌 Description

This change pins the installed version of `@actions/tool-cache` to major version 3.

<!-- Add a more detailed description of the changes if needed. -->

The `@actions/tool-cache` package was recently converted to an ESM module: https://github.com/actions/toolkit/pull/2274. This is incompatible with the usage of `require` in the actionlint script:

https://github.com/raven-actions/actionlint/blob/580b34edf3f0039a5691481c6081049971ecd530/action.yml#L217-L218 

## 🔗 Related issue

<!-- If your PR refers to a related issue, link it here. -->

Fixes: https://github.com/raven-actions/actionlint/issues/51

## 📚 Type of change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📝 Examples / docs / tutorials
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🚨 Security fix
- [x] ⬆️ Dependencies update

## ✔️ Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`Code of Conduct`](https://github.com/raven-actions/.workflows/blob/main/.github/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`Contributing`](https://github.com/raven-actions/.workflows/blob/main/.github/CONTRIBUTING.md) guide.
