### PR TITLE
docs: fix make link to code of conduct absolute

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ To contribute, please follow these steps:
 
 ## 🔰 Code of Conduct
 
-All contributors are expected to adhere to the project name code of conduct. Therefore, please review it before contributing [`Code of Conduct`](CODE_OF_CONDUCT.md)
+All contributors are expected to adhere to the project name code of conduct. Therefore, please review it before contributing [`Code of Conduct`](/.github/CODE_OF_CONDUCT.md)
 
 ## 🛡️ License
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
Fix incorrect linking of the code of conduct by making the link absolute. This makes the link work via both the main repository pages' Contributing tab as well as when navigating directly to the Contributing file.

<!-- Add a more detailed description of the changes if needed. -->

## 🔗 Related issue

<!-- If your PR refers to a related issue, link it here. -->
Fixes: #54

## 📚 Type of change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📝 Examples / docs / tutorials
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🚨 Security fix
- [ ] ⬆️ Dependencies update

## ✔️ Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`Code of Conduct`](https://github.com/raven-actions/.workflows/blob/main/.github/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`Contributing`](https://github.com/raven-actions/.workflows/blob/main/.github/CONTRIBUTING.md) guide.
