### PR TITLE
fix: use legacy peer dependencies to resolve installation failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -204,7 +204,7 @@ runs:
 
     - name: Install dependencies
       if: ${{ steps.tool-cache.outputs.cache-hit != 'true' }}
-      run: npm install --no-save --ignore-scripts @actions/tool-cache@3.0.1
+      run: npm install --no-save --ignore-scripts --legacy-peer-deps @actions/tool-cache@3.0.1
       shell: ${{ (runner.os == 'Windows' && 'pwsh') || 'bash' }}
       working-directory: ${{ inputs.working-directory }}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 💌 Description

Update the npm install command to include the `--legacy-peer-deps` flag to resolve dependency installation failures.

Currently the action is throwing:

```
Cache not found for input keys: actionlint-1.7.11-Linux-X64
Run npm install --no-save --ignore-scripts @actions/tool-cache@3.0.1
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: eslint-plugin-import@2.32.0
npm error Found: eslint@10.0.1
npm error node_modules/eslint
npm error   peer eslint@"^6.0.0 || ^7.0.0 || >=8.0.0" from @eslint-community/eslint-utils@4.9.1
npm error   node_modules/@eslint-community/eslint-utils
npm error     @eslint-community/eslint-utils@"^4.9.1" from @typescript-eslint/utils@8.56.0
npm error     node_modules/@typescript-eslint/utils
npm error       @typescript-eslint/utils@"8.56.0" from @typescript-eslint/eslint-plugin@8.56.0
npm error       node_modules/@typescript-eslint/eslint-plugin
npm error         peerOptional @typescript-eslint/eslint-plugin@"^8.0.0" from eslint-plugin-jest@29.15.0
npm error         node_modules/eslint-plugin-jest
npm error         1 more (typescript-eslint)
npm error       3 more (@typescript-eslint/type-utils, eslint-plugin-jest, typescript-eslint)
npm error     @eslint-community/eslint-utils@"^4.8.0" from eslint@10.0.1
npm error     1 more (eslint)
npm error   peerOptional eslint@"^8.40 || 9 || 10" from @eslint/compat@2.0.2
npm error   node_modules/@eslint/compat
npm error     dev @eslint/compat@"^2.0.2" from the root project
npm error   12 more (@eslint/js, @typescript-eslint/eslint-plugin, ...)
npm error
npm error Could not resolve dependency:
npm error peer eslint@"^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" from eslint-plugin-import@2.32.0
npm error node_modules/eslint-plugin-import
npm error   peerOptional eslint-plugin-import@"*" from eslint-import-resolver-typescript@4.4.4
npm error   node_modules/eslint-import-resolver-typescript
npm error     dev eslint-import-resolver-typescript@"^4.4.4" from the root project
npm error   dev eslint-plugin-import@"^2.32.0" from the root project
npm error
npm error Conflicting peer dependency: eslint@9.39.3
npm error node_modules/eslint
npm error   peer eslint@"^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" from eslint-plugin-import@2.32.0
npm error   node_modules/eslint-plugin-import
npm error     peerOptional eslint-plugin-import@"*" from eslint-import-resolver-typescript@4.4.4
npm error     node_modules/eslint-import-resolver-typescript
npm error       dev eslint-import-resolver-typescript@"^4.4.4" from the root project
npm error     dev eslint-plugin-import@"^2.32.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /home/runner/.npm/_logs/2026-02-22T23_48_58_065Z-eresolve-report.txt
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-02-22T23_48_58_065Z-debug-0.log
Error: Process completed with exit code 1.
```

## 🔗 Related issue

<!-- If your PR refers to a related issue, link it here. -->
Fixes: #

## 📚 Type of change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📝 Examples / docs / tutorials
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🚨 Security fix
- [x] ⬆️ Dependencies update

## ✔️ Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`Code of Conduct`](https://github.com/raven-actions/.workflows/blob/main/.github/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`Contributing`](https://github.com/raven-actions/.workflows/blob/main/.github/CONTRIBUTING.md) guide.

