### PR TITLE
fix: optimize tool release fetching to reduce API calls and handle errors gracefully

### DIFF
--- a/.github/linters/.lychee.toml
+++ b/.github/linters/.lychee.toml
@@ -130,6 +130,10 @@ exclude = [
   '^https://cli\.github\.com',
   '^https://www\.linkedin\.com',
   '^https://web\.archive\.org/web/',
+  # Templated/placeholder URLs from the embedded action scripts (e.g. ${VAR}); not real links.
+  # lychee percent-encodes `{`/`}` to %7B/%7D, so match both the encoded and raw forms.
+  '%7[Bb]',
+  '\$\{',
 ]
 
 # Exclude these filesystem paths from getting checked.

--- a/.github/linters/.lychee.toml
+++ b/.github/linters/.lychee.toml
@@ -133,17 +133,18 @@ exclude = [
 ]
 
 # Exclude these filesystem paths from getting checked.
+# NOTE: lychee compiles these as regular expressions (like `exclude`), not globs.
 exclude_path = [
-  ".github/configs/release-drafter.yml",
-  "*/node_modules/*",
-  "*/.git/*",
-  "*/.venv/*",
-  "*/venv/*",
-  "*/__pycache__/*",
-  "*/target/*",
-  "*/build/*",
-  "*/dist/*",
-  "*/megalinter-reports/*",
+  '\.github/configs/release-drafter\.yml',
+  '(^|/)node_modules(/|$)',
+  '(^|/)\.git(/|$)',
+  '(^|/)\.venv(/|$)',
+  '(^|/)venv(/|$)',
+  '(^|/)__pycache__(/|$)',
+  '(^|/)target(/|$)',
+  '(^|/)build(/|$)',
+  '(^|/)dist(/|$)',
+  '(^|/)megalinter-reports(/|$)',
 ]
 
 # URLs to check (supports regex). Has preference over all excludes.

--- a/.github/linters/.lychee.toml
+++ b/.github/linters/.lychee.toml
@@ -97,14 +97,10 @@ method = "get"
 
 # Custom request headers
 # header = { "accept" = "text/html", "x-custom-header" = "value" }
-headers = [
-  # Avoid being blocked by GitHub's anti-bot measures
-  "Accept=text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-  # Some sites require this header
-  "Accept-Language=en-US,en;q=0.5",
-  # Disable compression to avoid issues with some servers
-  "Accept-Encoding=identity",
-]
+# Accept: avoid being blocked by GitHub's anti-bot measures
+# Accept-Language: some sites require this header
+# Accept-Encoding=identity: disable compression to avoid issues with some servers
+header = { "Accept" = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "Accept-Language" = "en-US,en;q=0.5", "Accept-Encoding" = "identity" }
 
 # Remap URI matching pattern to different URI.
 # remap = ["https://example.com http://example.invalid"]

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
 
           // discover the latest tag by following the redirect on the public releases/latest page (no API call)
           async function getLatestTagFromRedirect() {
-            const https = require('https')
+            const https = await import('node:https')
             return await new Promise((resolve, reject) => {
               const request = https.get(
                 `https://github.com/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/releases/latest`,
@@ -238,7 +238,13 @@ runs:
         github-token: ${{ inputs.github-token || inputs.token || env.GITHUB_TOKEN }}
         script: |
           // dependencies
-          const tc = require('@actions/tool-cache')
+          // github-script runs this inline script in a non-module context, so the workspace-installed
+          // package is resolved from the working directory and then imported as ESM
+          const { createRequire } = await import('node:module')
+          const { pathToFileURL } = await import('node:url')
+          const { join } = await import('node:path')
+          const toolCacheUrl = pathToFileURL(createRequire(join(process.cwd(), 'index.js')).resolve('@actions/tool-cache')).href
+          const tc = (await import(toolCacheUrl)).default
 
           // input envs
           const { INPUT_TOOL_NAME, INPUT_TOOL_DIR_PATH, INPUT_TOOL_DOWNLOAD_URL, INPUT_MATCHER_DOWNLOAD_URL, INPUT_MATCHER_PATH } = process.env
@@ -416,8 +422,8 @@ runs:
           const { exitCode, stdout, stderr } = await exec.getExecOutput(INPUT_TOOL_EXECUTABLE, toolFlags, { silent: true, ignoreReturnCode: true })
 
           //if (INPUT_JSON === 'true') {
-          //  const fs = require('fs')
-          //   const path = require('path')
+          //  const fs = await import('node:fs')
+          //   const path = await import('node:path')
           //   const jsonPath = path.join(process.env.GITHUB_WORKSPACE, 'actionlint.json')
           //   fs.writeFileSync(jsonPath, stdout)
           //   core.info(`##[add-annotation]file=${jsonPath},title=actionlint.json`)

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
 
     - name: Install dependencies
       if: ${{ steps.tool-cache.outputs.cache-hit != 'true' }}
-      run: npm install --no-save --ignore-scripts --legacy-peer-deps @actions/tool-cache@3.0.1
+      run: npm install --no-save --ignore-scripts --legacy-peer-deps @actions/tool-cache@4.0.0
       shell: ${{ (runner.os == 'Windows' && 'pwsh') || 'bash' }}
       working-directory: ${{ inputs.working-directory }}
 
@@ -238,13 +238,13 @@ runs:
         github-token: ${{ inputs.github-token || inputs.token || env.GITHUB_TOKEN }}
         script: |
           // dependencies
-          // github-script runs this inline script in a non-module context, so the workspace-installed
-          // package is resolved from the working directory and then imported as ESM
-          const { createRequire } = await import('node:module')
+          // @actions/tool-cache v4 is a pure-ESM package installed into the workspace; github-script
+          // evaluates this inline script in a non-module context where bare specifiers can't be resolved,
+          // so import it directly via its file URL under the working directory
           const { pathToFileURL } = await import('node:url')
           const { join } = await import('node:path')
-          const toolCacheUrl = pathToFileURL(createRequire(join(process.cwd(), 'index.js')).resolve('@actions/tool-cache')).href
-          const tc = (await import(toolCacheUrl)).default
+          const toolCacheEntry = join(process.cwd(), 'node_modules', '@actions', 'tool-cache', 'lib', 'tool-cache.js')
+          const tc = await import(pathToFileURL(toolCacheEntry).href)
 
           // input envs
           const { INPUT_TOOL_NAME, INPUT_TOOL_DIR_PATH, INPUT_TOOL_DOWNLOAD_URL, INPUT_MATCHER_DOWNLOAD_URL, INPUT_MATCHER_PATH } = process.env

--- a/action.yml
+++ b/action.yml
@@ -147,34 +147,57 @@ runs:
               process.exit(core.ExitCode.Failure)
           }
 
-          // helpers
-          async function getToolReleaseLatest() {
+          // resolve the release tag while avoiding GitHub API calls where possible
+          // (REST calls count against the GITHUB_TOKEN rate limit, which busy CI can exhaust)
+          const isLatest = !INPUT_TOOL_SEMVER || INPUT_TOOL_SEMVER === 'latest'
+
+          // discover the latest tag by following the redirect on the public releases/latest page (no API call)
+          async function getLatestTagFromRedirect() {
+            const https = require('https')
+            return await new Promise((resolve, reject) => {
+              const request = https.get(
+                `https://github.com/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/releases/latest`,
+                { headers: { 'user-agent': INPUT_TOOL_NAME } },
+                (res) => {
+                  res.resume() // drain the response so the socket can close
+                  const location = res.headers['location']
+                  if (res.statusCode >= 300 && res.statusCode < 400 && location) {
+                    resolve(location.split('/').pop().trim())
+                  } else {
+                    reject(new Error(`unexpected response (status: ${res.statusCode})`))
+                  }
+                }
+              )
+              request.setTimeout(10000, () => request.destroy(new Error('request timed out')))
+              request.on('error', reject)
+            })
+          }
+
+          // proxy-aware fallback via the authenticated client; only used if the redirect approach fails
+          async function getLatestTagFromApi() {
             const response = await github.rest.repos.getLatestRelease({
               owner: INPUT_REPO_OWNER,
               repo: INPUT_REPO_NAME
             })
-            return response.data
+            return response.data.tag_name
           }
 
-          async function getToolReleaseByTag(versionTag) {
-            const response = await github.rest.repos.getReleaseByTag({
-              owner: INPUT_REPO_OWNER,
-              repo: INPUT_REPO_NAME,
-              tag: versionTag
-            })
-            return response.data
+          let versionTag
+          if (isLatest) {
+            try {
+              versionTag = await getLatestTagFromRedirect()
+            } catch (err) {
+              core.debug(`[${INPUT_TOOL_NAME}] latest-release redirect failed (${err.message}); falling back to GitHub API`)
+              versionTag = await getLatestTagFromApi()
+            }
+          } else {
+            // pinned version: build the tag directly, no network call needed
+            versionTag = `v${INPUT_TOOL_SEMVER.replace(/^v/, '')}`
           }
 
-          // get tool release data
-          const release =
-            INPUT_TOOL_SEMVER === 'latest' || INPUT_TOOL_SEMVER === '' || INPUT_TOOL_SEMVER === undefined || INPUT_TOOL_SEMVER === null
-              ? await getToolReleaseLatest()
-              : await getToolReleaseByTag(`v${INPUT_TOOL_SEMVER}`)
-
-          const versionTag = release.tag_name
           const versionSemVer = versionTag.replace(/^v/, '')
           const toolDirPath = core.toPlatformPath(`${RUNNER_TEMP}/${INPUT_TOOL_NAME}-${versionSemVer}`)
-          const toolDownloadUrl = release.assets.find(asset => asset.name === `${INPUT_TOOL_NAME}_${versionSemVer}_${toolOs}_${toolArch}.${toolExt}`).browser_download_url.trim()
+          const toolDownloadUrl = `https://github.com/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/releases/download/${versionTag}/${INPUT_TOOL_NAME}_${versionSemVer}_${toolOs}_${toolArch}.${toolExt}`
           const matcherDownloadUrl = `https://raw.githubusercontent.com/${INPUT_REPO_OWNER}/${INPUT_REPO_NAME}/${versionTag}/.github/actionlint-matcher.json`
           const matcherPath = core.toPlatformPath(`${toolDirPath}/actionlint-matcher.json`)
 
@@ -222,7 +245,16 @@ runs:
 
           // download tool
           await io.mkdirP(INPUT_TOOL_DIR_PATH)
-          const toolTempPath = await tc.downloadTool(INPUT_TOOL_DOWNLOAD_URL)
+          let toolTempPath
+          try {
+            toolTempPath = await tc.downloadTool(INPUT_TOOL_DOWNLOAD_URL)
+          } catch (err) {
+            if (err && err.httpStatusCode === 404) {
+              core.setFailed(`[${INPUT_TOOL_NAME}] Release asset not found (HTTP 404) - check the 'version' input points to a published release: ${INPUT_TOOL_DOWNLOAD_URL}`)
+              process.exit(core.ExitCode.Failure)
+            }
+            throw err
+          }
 
           // extract tool
           if (INPUT_TOOL_DOWNLOAD_URL.endsWith('.zip')) {

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
 
     - name: Install dependencies
       if: ${{ steps.tool-cache.outputs.cache-hit != 'true' }}
-      run: npm install --no-save --ignore-scripts --legacy-peer-deps @actions/tool-cache@4.0.0
+      run: npm install --prefix "${{ runner.temp }}/actionlint-action" --no-save --no-package-lock --no-audit --no-fund --ignore-scripts --legacy-peer-deps @actions/tool-cache@4.0.0
       shell: ${{ (runner.os == 'Windows' && 'pwsh') || 'bash' }}
       working-directory: ${{ inputs.working-directory }}
 
@@ -238,12 +238,13 @@ runs:
         github-token: ${{ inputs.github-token || inputs.token || env.GITHUB_TOKEN }}
         script: |
           // dependencies
-          // @actions/tool-cache v4 is a pure-ESM package installed into the workspace; github-script
-          // evaluates this inline script in a non-module context where bare specifiers can't be resolved,
-          // so import it directly via its file URL under the working directory
+          // @actions/tool-cache v4 is a pure-ESM package installed into an isolated RUNNER_TEMP dir, so it
+          // neither pollutes nor is affected by the user's workspace node_modules; github-script evaluates
+          // this inline script in a non-module context where bare specifiers can't be resolved, so import
+          // it directly via its file URL
           const { pathToFileURL } = await import('node:url')
           const { join } = await import('node:path')
-          const toolCacheEntry = join(process.cwd(), 'node_modules', '@actions', 'tool-cache', 'lib', 'tool-cache.js')
+          const toolCacheEntry = join(process.env.RUNNER_TEMP, 'actionlint-action', 'node_modules', '@actions', 'tool-cache', 'lib', 'tool-cache.js')
           const tc = await import(pathToFileURL(toolCacheEntry).href)
 
           // input envs


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 💌 Description

This pull request improves the way the GitHub Action resolves and downloads tool releases, focusing on reducing API usage and providing better error handling for missing release assets. The main changes include optimizing how the latest release tag is determined to avoid unnecessary GitHub API calls, constructing download URLs directly, and improving error messages for missing assets.

**Release resolution and download improvements:**

* The logic for resolving the latest release tag now first tries to follow the public `/releases/latest` HTTP redirect (which does not consume API rate limits), and only falls back to the GitHub API if that fails. This reduces the risk of hitting API rate limits in busy CI environments.
* For pinned versions, the release tag is constructed directly without any network call, further reducing unnecessary API usage.
* The download URL for the tool asset is now constructed directly based on the resolved tag, instead of relying on the API response.

**Error handling improvements:**

* If the tool asset download returns a 404 error, the action now provides a clear failure message indicating the asset was not found and suggests checking the version input, then exits gracefully.

## 🔗 Related issue

<!-- If your PR refers to a related issue, link it here. -->
Fixes: #

## 📚 Type of change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📝 Examples / docs / tutorials
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🚨 Security fix
- [ ] ⬆️ Dependencies update

## ✔️ Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`Code of Conduct`](https://github.com/raven-actions/.workflows/blob/main/.github/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`Contributing`](https://github.com/raven-actions/.workflows/blob/main/.github/CONTRIBUTING.md) guide.
