### PR TITLE
ci: add dog-food regression test for pnpm/workspace repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,52 @@ jobs:
           echo "actionlint cache used: ${{ steps.actionlint.outputs.cache-hit }}"
           # shellcheck disable=SC2242
           exit ${{ steps.actionlint.outputs.exit-code }}
+
+  dog-food-non-npm:
+    name: Dog food (pnpm/non-npm repo)
+    needs:
+      - dog-food
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Regression guard for https://github.com/raven-actions/actionlint/issues/26:
+      # the action's internal `npm install` of @actions/tool-cache must not be broken by a
+      # consuming repo that uses pnpm/workspaces. A `workspace:` protocol dependency makes a
+      # plain `npm install` fail with EUNSUPPORTEDPROTOCOL, so this simulates such a repo.
+      - name: Simulate a pnpm/workspace (non-npm) repo
+        run: |
+          cat > package.json <<'EOF'
+          {
+            "name": "non-npm-consumer",
+            "version": "1.0.0",
+            "private": true,
+            "packageManager": "pnpm@9.0.0",
+            "dependencies": {
+              "some-internal-pkg": "workspace:*"
+            },
+            "scripts": {
+              "preinstall": "npx only-allow pnpm"
+            }
+          }
+          EOF
+          printf 'packages:\n  - "packages/*"\n' > pnpm-workspace.yaml
+
+      - name: actionlint Action
+        id: actionlint
+        uses: ./
+        with:
+          cache: false # force the internal npm install to run (skip the cache-hit short-circuit)
+          files: "tests/fixtures/*.yml, tests/fixtures/*.yaml"
+          flags: "-ignore SC2086"
+          fail-on-error: false
+
+      - name: Verify the tool installed and ran
+        run: |
+          echo "version: ${{ steps.actionlint.outputs.version-semver }} / exit-code: ${{ steps.actionlint.outputs.exit-code }}"
+          # outputs are only populated once environment + npm install + download succeeded
+          if [ -z "${{ steps.actionlint.outputs.exit-code }}" ]; then
+            echo "::error::actionlint did not run - internal npm install of @actions/tool-cache likely failed (#26 regression)"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Regression guard for https://github.com/raven-actions/actionlint/issues/26:
-      # the action's internal `npm install` of @actions/tool-cache must not be broken by a
-      # consuming repo that uses pnpm/workspaces. A `workspace:` protocol dependency makes a
-      # plain `npm install` fail with EUNSUPPORTEDPROTOCOL, so this simulates such a repo.
+      # Regression guard for issues #26 and #60:
+      #   #26 - the action's internal `npm install` of @actions/tool-cache must not break in a
+      #         consuming repo that uses pnpm/workspaces (a `workspace:` protocol dependency makes
+      #         a plain `npm install` fail with EUNSUPPORTEDPROTOCOL).
+      #   #60 - the action must not leave a stray node_modules behind in the workspace.
       - name: Simulate a pnpm/workspace (non-npm) repo
         run: |
           cat > package.json <<'EOF'
@@ -148,11 +149,16 @@ jobs:
           flags: "-ignore SC2086"
           fail-on-error: false
 
-      - name: Verify the tool installed and ran
+      - name: Verify the tool ran and left no stray node_modules
         run: |
           echo "version: ${{ steps.actionlint.outputs.version-semver }} / exit-code: ${{ steps.actionlint.outputs.exit-code }}"
           # outputs are only populated once environment + npm install + download succeeded
           if [ -z "${{ steps.actionlint.outputs.exit-code }}" ]; then
             echo "::error::actionlint did not run - internal npm install of @actions/tool-cache likely failed (#26 regression)"
+            exit 1
+          fi
+          # the action must not pollute the workspace with a node_modules directory
+          if [ -d node_modules ]; then
+            echo "::error::stray node_modules left in the workspace (#60 regression)"
             exit 1
           fi


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 💌 Description

This pull request adds a new CI job to improve regression testing for pnpm and workspace protocol compatibility. The main focus is to ensure the action works correctly in repositories that use pnpm and workspace dependencies, and that it does not leave behind unwanted `node_modules` directories.

**Regression test enhancements:**

* Added a new `dog-food-non-npm` job to `.github/workflows/ci.yml` that simulates a pnpm/workspace (non-npm) repository. This tests for regressions related to internal `npm install` failures with workspace protocol dependencies (issue #26) and ensures the action does not leave a stray `node_modules` directory in the workspace (issue #60).
## 🔗 Related issue

<!-- If your PR refers to a related issue, link it here. -->
Fixes: #26
Fixes: #60

## 📚 Type of change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📝 Examples / docs / tutorials
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🚨 Security fix
- [ ] ⬆️ Dependencies update

## ✔️ Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`Code of Conduct`](https://github.com/raven-actions/.workflows/blob/main/.github/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`Contributing`](https://github.com/raven-actions/.workflows/blob/main/.github/CONTRIBUTING.md) guide.
